### PR TITLE
Implement advanced access control for teachers and headmaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Berikut adalah status implementasi fitur berdasarkan dokumen desain:
     *   [X] Telah dilakukan testing manual untuk berbagai skenario input (valid, invalid, berbagai tipe).
     *   [X] Tampilan rekap nilai per siswa dan per mata pelajaran (Guru: pemilihan konteks, tampilan tabel, aksi Edit/Hapus; Siswa: tampilan nilai per mapel; Ortu: pemilihan anak & tampilan nilai anak).
     *   [X] Filter kelas/mapel yang diajar guru pada halaman pemilihan konteks (Filter kelas berdasarkan wali kelas; Filter mapel berdasarkan penugasan guru di kelas tersebut).
-    *   [X] Fitur edit/hapus data penilaian yang sudah dimasukkan (Controller, View dasar, Rute, Hak Akses dasar, terintegrasi di halaman rekap).
+    *   [X] Fitur edit/hapus data penilaian yang sudah dimasukkan (Controller, View dasar, Rute, Hak Akses diperkuat - guru hanya bisa edit/hapus milik sendiri dan jika masih mengajar kelas/mapel terkait, terintegrasi di halaman rekap).
 *   **[ ] Modul Projek P5**
     *   [ ] Struktur Tabel Database (perlu dirancang lebih detail berdasarkan dokumen)
     *   [ ] Pengaturan projek oleh koordinator
@@ -106,7 +106,7 @@ Berikut adalah status implementasi fitur berdasarkan dokumen desain:
     *   [X] Mengelola Data Induk (Siswa, Guru, Mapel, Kelas - CRUD Penuh).
     *   [ ] Mengatur pembagian siswa ke dalam rombel (detail penempatan siswa belum).
 *   **Kepala Sekolah**:
-    *   [X] Akses read-only ke Data Induk (via Controller, halaman index).
+    *   [X] Akses read-only ke Data Induk (Controller membatasi aksi CUD, tombol aksi terkait disembunyikan dari tampilan).
     *   [ ] Dasbor eksekutif.
     *   [ ] Memantau aktivitas guru.
     *   [ ] Membuat dan menyebarkan pengumuman.

--- a/app/Views/admin/classes/index.php
+++ b/app/Views/admin/classes/index.php
@@ -5,9 +5,11 @@
 <div class="container-fluid">
     <div class="d-sm-flex align-items-center justify-content-between mb-4">
         <h1 class="h3 mb-0 text-gray-800"><?= esc($title ?? 'Manage Classes (Rombel)') ?></h1>
-        <a href="<?= site_url('admin/classes/new') ?>" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-lg"></i> Add New Class
-        </a>
+        <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+            <a href="<?= site_url('admin/classes/new') ?>" class="btn btn-primary btn-sm">
+                <i class="bi bi-plus-lg"></i> Add New Class
+            </a>
+        <?php endif; ?>
     </div>
 
     <?php if (session()->getFlashdata('success')) : ?>
@@ -37,7 +39,9 @@
                             <th>Academic Year</th>
                             <th>Fase</th>
                             <th>Wali Kelas</th>
-                            <th>Actions</th>
+                            <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                <th>Actions</th>
+                            <?php endif; ?>
                         </tr>
                     </thead>
                     <tbody>
@@ -49,23 +53,26 @@
                                     <td><?= esc($class_item['academic_year']) ?></td>
                                     <td><?= esc($class_item['fase']) ?></td>
                                     <td><?= esc($class_item['wali_kelas_name'] ?? 'N/A') ?></td>
-                                    <td>
-                                        <a href="<?= site_url('admin/classes/edit/' . $class_item['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
-                                            <i class="bi bi-pencil-fill"></i>
-                                        </a>
-                                        <a href="<?= site_url('admin/classes/delete/' . $class_item['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this class? This action cannot be undone and might affect related student records.');">
-                                            <i class="bi bi-trash-fill"></i>
-                                        </a>
-                                        <!-- Add link to manage students in class later -->
-                                        <!-- <a href="<?= site_url('admin/classes/students/' . $class_item['id']) ?>" class="btn btn-info btn-sm" title="Manage Students">
-                                            <i class="bi bi-people-fill"></i>
-                                        </a> -->
-                                    </td>
+                                    <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                        <td>
+                                            <a href="<?= site_url('admin/classes/edit/' . $class_item['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
+                                                <i class="bi bi-pencil-fill"></i>
+                                            </a>
+                                            <a href="<?= site_url('admin/classes/delete/' . $class_item['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this class? This action cannot be undone and might affect related student records.');">
+                                                <i class="bi bi-trash-fill"></i>
+                                            </a>
+                                            <!-- Add link to manage students in class later -->
+                                            <!-- <a href="<?= site_url('admin/classes/students/' . $class_item['id']) ?>" class="btn btn-info btn-sm" title="Manage Students">
+                                                <i class="bi bi-people-fill"></i>
+                                            </a> -->
+                                        </td>
+                                    <?php endif; ?>
                                 </tr>
                             <?php endforeach; ?>
                         <?php else : ?>
                             <tr>
-                                <td colspan="6" class="text-center">No classes found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 6 : 5 ?>" class="text-center">No classes found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 6 : 5 ?>" class="text-center">No classes found.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>

--- a/app/Views/admin/students/index.php
+++ b/app/Views/admin/students/index.php
@@ -5,9 +5,11 @@
 <div class="container-fluid">
     <div class="d-sm-flex align-items-center justify-content-between mb-4">
         <h1 class="h3 mb-0 text-gray-800"><?= esc($title ?? 'Manage Students') ?></h1>
-        <a href="<?= site_url('admin/students/new') ?>" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-lg"></i> Add New Student
-        </a>
+        <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+            <a href="<?= site_url('admin/students/new') ?>" class="btn btn-primary btn-sm">
+                <i class="bi bi-plus-lg"></i> Add New Student
+            </a>
+        <?php endif; ?>
     </div>
 
     <?php if (session()->getFlashdata('success')) : ?>
@@ -37,7 +39,9 @@
                             <th>Full Name</th>
                             <th>User ID (Login)</th>
                             <th>Parent User ID</th>
-                            <th>Actions</th>
+                            <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                <th>Actions</th>
+                            <?php endif; ?>
                         </tr>
                     </thead>
                     <tbody>
@@ -49,19 +53,22 @@
                                     <td><?= esc($student['full_name']) ?></td>
                                     <td><?= esc($student['user_id']) ?></td>
                                     <td><?= esc($student['parent_user_id']) ?></td>
-                                    <td>
-                                        <a href="<?= site_url('admin/students/edit/' . $student['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
-                                            <i class="bi bi-pencil-fill"></i>
-                                        </a>
-                                        <a href="<?= site_url('admin/students/delete/' . $student['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this student? This action cannot be undone.');">
-                                            <i class="bi bi-trash-fill"></i>
-                                        </a>
-                                    </td>
+                                    <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                        <td>
+                                            <a href="<?= site_url('admin/students/edit/' . $student['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
+                                                <i class="bi bi-pencil-fill"></i>
+                                            </a>
+                                            <a href="<?= site_url('admin/students/delete/' . $student['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this student? This action cannot be undone.');">
+                                                <i class="bi bi-trash-fill"></i>
+                                            </a>
+                                        </td>
+                                    <?php endif; ?>
                                 </tr>
                             <?php endforeach; ?>
                         <?php else : ?>
                             <tr>
-                                <td colspan="6" class="text-center">No students found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 6 : 5 ?>" class="text-center">No students found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 6 : 5 ?>" class="text-center">No students found.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>

--- a/app/Views/admin/subjects/index.php
+++ b/app/Views/admin/subjects/index.php
@@ -5,9 +5,11 @@
 <div class="container-fluid">
     <div class="d-sm-flex align-items-center justify-content-between mb-4">
         <h1 class="h3 mb-0 text-gray-800"><?= esc($title ?? 'Manage Subjects') ?></h1>
-        <a href="<?= site_url('admin/subjects/new') ?>" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-lg"></i> Add New Subject
-        </a>
+        <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+            <a href="<?= site_url('admin/subjects/new') ?>" class="btn btn-primary btn-sm">
+                <i class="bi bi-plus-lg"></i> Add New Subject
+            </a>
+        <?php endif; ?>
     </div>
 
     <?php if (session()->getFlashdata('success')) : ?>
@@ -36,7 +38,9 @@
                             <th>Subject Code</th>
                             <th>Subject Name</th>
                             <th>Type</th>
-                            <th>Actions</th>
+                            <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                <th>Actions</th>
+                            <?php endif; ?>
                         </tr>
                     </thead>
                     <tbody>
@@ -53,19 +57,22 @@
                                             <span class="badge bg-secondary">Wajib (Core)</span>
                                         <?php endif; ?>
                                     </td>
-                                    <td>
-                                        <a href="<?= site_url('admin/subjects/edit/' . $subject['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
-                                            <i class="bi bi-pencil-fill"></i>
-                                        </a>
-                                        <a href="<?= site_url('admin/subjects/delete/' . $subject['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this subject? This action cannot be undone.');">
-                                            <i class="bi bi-trash-fill"></i>
-                                        </a>
-                                    </td>
+                                    <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                        <td>
+                                            <a href="<?= site_url('admin/subjects/edit/' . $subject['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
+                                                <i class="bi bi-pencil-fill"></i>
+                                            </a>
+                                            <a href="<?= site_url('admin/subjects/delete/' . $subject['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this subject? This action cannot be undone.');">
+                                                <i class="bi bi-trash-fill"></i>
+                                            </a>
+                                        </td>
+                                    <?php endif; ?>
                                 </tr>
                             <?php endforeach; ?>
                         <?php else : ?>
                             <tr>
-                                <td colspan="5" class="text-center">No subjects found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 5 : 4 ?>" class="text-center">No subjects found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 5 : 4 ?>" class="text-center">No subjects found.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>

--- a/app/Views/admin/teachers/index.php
+++ b/app/Views/admin/teachers/index.php
@@ -5,9 +5,11 @@
 <div class="container-fluid">
     <div class="d-sm-flex align-items-center justify-content-between mb-4">
         <h1 class="h3 mb-0 text-gray-800"><?= esc($title ?? 'Manage Teachers') ?></h1>
-        <a href="<?= site_url('admin/teachers/new') ?>" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-lg"></i> Add New Teacher
-        </a>
+        <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+            <a href="<?= site_url('admin/teachers/new') ?>" class="btn btn-primary btn-sm">
+                <i class="bi bi-plus-lg"></i> Add New Teacher
+            </a>
+        <?php endif; ?>
     </div>
 
     <?php if (session()->getFlashdata('success')) : ?>
@@ -36,7 +38,9 @@
                             <th>NIP</th>
                             <th>Full Name</th>
                             <th>User ID (Login)</th>
-                            <th>Actions</th>
+                            <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                <th>Actions</th>
+                            <?php endif; ?>
                         </tr>
                     </thead>
                     <tbody>
@@ -47,19 +51,22 @@
                                     <td><?= esc($teacher['nip']) ?></td>
                                     <td><?= esc($teacher['full_name']) ?></td>
                                     <td><?= esc($teacher['user_id']) ?></td>
-                                    <td>
-                                        <a href="<?= site_url('admin/teachers/edit/' . $teacher['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
-                                            <i class="bi bi-pencil-fill"></i>
-                                        </a>
-                                        <a href="<?= site_url('admin/teachers/delete/' . $teacher['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this teacher? This action cannot be undone.');">
-                                            <i class="bi bi-trash-fill"></i>
-                                        </a>
-                                    </td>
+                                    <?php if (hasRole(['Administrator Sistem', 'Staf Tata Usaha'])) : ?>
+                                        <td>
+                                            <a href="<?= site_url('admin/teachers/edit/' . $teacher['id']) ?>" class="btn btn-warning btn-sm" title="Edit">
+                                                <i class="bi bi-pencil-fill"></i>
+                                            </a>
+                                            <a href="<?= site_url('admin/teachers/delete/' . $teacher['id']) ?>" class="btn btn-danger btn-sm" title="Delete" onclick="return confirm('Are you sure you want to delete this teacher? This action cannot be undone.');">
+                                                <i class="bi bi-trash-fill"></i>
+                                            </a>
+                                        </td>
+                                    <?php endif; ?>
                                 </tr>
                             <?php endforeach; ?>
                         <?php else : ?>
                             <tr>
-                                <td colspan="5" class="text-center">No teachers found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 5 : 4 ?>" class="text-center">No teachers found.</td>
+                                <td colspan="<?= hasRole(['Administrator Sistem', 'Staf Tata Usaha']) ? 5 : 4 ?>" class="text-center">No teachers found.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>


### PR DESCRIPTION
- Enhanced granular access for teachers in the Assessment module:
  - Teachers can only access and manage assessments for classes/subjects they are assigned to.
  - Stricter ownership and assignment checks for editing/deleting assessments.
  - Validated that students belong to the selected class during assessment input.
- Implemented read-only access for Headmasters in Data Induk modules:
  - Controllers now prevent CUD operations for Headmasters.
  - Views hide CUD action buttons for Headmasters.
- Updated AGENTS.md and README.md to reflect these changes.