### PR TITLE
feat: Implement P5 assessment input and basic reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,23 +248,37 @@ Berikut adalah ringkasan relasi kunci (foreign key) antar tabel utama dalam data
 *   **[P] Modul Ekspor ke e-Rapor (Tahap Awal Selesai, Perlu Penyempurnaan)**:
     *   Controller `WaliKelas/EraporController` dibuat untuk form dan proses ekspor.
     *   Model `AssessmentModel::getExportDataForErapor()` diimplementasikan untuk mengambil rata-rata nilai sumatif.
-        *   **CATATAN PENTING:** Logika pemfilteran nilai sumatif berdasarkan rentang tanggal semester yang akurat **perlu penyempurnaan** untuk memastikan data yang diekspor hanya dari semester yang dipilih. Saat ini merata-ratakan semua sumatif yang cocok (siswa, kelas, mapel) tanpa filter tanggal yang ketat.
+        *   Logika pemfilteran nilai sumatif berdasarkan rentang tanggal semester (Ganjil: Juli-Des, Genap: Jan-Juni dari tahun ajaran terkait) **telah disempurnakan**.
     *   View `wali_kelas/erapor/export_form.php` dibuat.
     *   Library `PhpSpreadsheet` diinstal dan digunakan untuk generate file `.xlsx`.
     *   Rute dan navigasi ditambahkan untuk Wali Kelas.
+    *   Pengguna disarankan memverifikasi output Excel dengan template e-Rapor aktual.
+*   **[P] Modul Projek P5 (Fitur Penilaian & Pelaporan Dasar)**:
+    *   **Fitur Input Penilaian P5 (Guru/Fasilitator)**:
+        *   Controller `Guru/P5AssessmentController.php` dibuat (method: `selectProject`, `showAssessmentForm`, `saveAssessments`).
+        *   Views `guru/p5assessments/select_project.php` dan `guru/p5assessments/assessment_form.php` dibuat.
+        *   Rute ditambahkan: `guru/p5assessments`, `guru/p5assessments/project/(:num)`, `guru/p5assessments/save/(:num)`.
+        *   Navigasi ditambahkan di menu guru.
+        *   **CATATAN HAK AKSES**: Saat ini, semua guru dapat memilih dan menginput penilaian untuk semua projek P5. Ini perlu dibatasi hanya untuk fasilitator yang ditugaskan pada projek setelah fitur penetapan fasilitator diimplementasikan.
+    *   **Fitur Pelaporan P5 (Admin/Koordinator)**:
+        *   Method `report($project_id)` ditambahkan ke `Admin/P5ProjectController.php`.
+        *   View `admin/p5projects/report.php` dibuat, menampilkan rekapitulasi penilaian per siswa per sub-elemen untuk sebuah projek, lengkap dengan DataTables untuk ekspor.
+        *   Rute `admin/p5projects/report/(:num)` ditambahkan.
+        *   Link ke laporan ditambahkan pada halaman daftar projek P5 di admin.
+        *   Hak akses dikontrol oleh filter grup admin dan permission `manage_p5_projects`.
 
 ## 6. Area Pengembangan Selanjutnya (Prioritas dari Dokumen Desain)
 
-1.  **Modul Penilaian (Bank Nilai) (Lanjutan)**:
-    *   (Item terkait optimasi form input dan penyempurnaan DataTables telah dianggap tuntas untuk lingkup saat ini. Pengembangan lebih lanjut pada area ini akan bersifat opsional atau berdasarkan kebutuhan baru).
-2.  **Modul Projek P5 (Fitur Lanjutan)**:
-    *   [ ] Fitur input penilaian P5 oleh Fasilitator/Guru.
-    *   [ ] Fitur Pelaporan P5 (rekapitulasi penilaian per siswa, progres projek, dll.).
-3.  **Penyempurnaan Modul Ekspor ke e-Rapor**:
-    *   Penyempurnaan logika pemfilteran data nilai sumatif per semester.
-    *   Verifikasi format kolom Excel terhadap template e-Rapor aktual.
-4.  **Penyempurnaan Hak Akses (Minor/Lanjutan)**:
-    *   Review dan audit berkelanjutan untuk memastikan konsistensi dan keamanan hak akses di seluruh modul, terutama untuk fitur-fitur baru yang akan dikembangkan.
+1.  **Modul Projek P5 (Fitur Lanjutan)**:
+    *   [ ] Implementasi fitur penetapan fasilitator/guru pendamping untuk setiap projek P5.
+    *   [ ] Penyempurnaan hak akses pada fitur Input Penilaian P5 agar hanya fasilitator terdaftar yang dapat menilai projeknya.
+    *   [ ] Fitur Pelaporan P5 yang lebih komprehensif (misalnya, rekapitulasi per siswa di semua projek, progres individu).
+    *   [ ] Ekspor data P5 untuk e-Rapor (jika formatnya didukung dan telah ditentukan).
+2.  **Penyempurnaan Modul Ekspor ke e-Rapor**:
+    *   Verifikasi lebih lanjut format kolom Excel terhadap template e-Rapor aktual oleh pengguna/pengembang dengan akses ke template.
+3.  **Penyempurnaan Hak Akses (Minor/Lanjutan)**:
+    *   Review dan audit berkelanjutan untuk memastikan konsistensi dan keamanan hak akses di seluruh modul.
+    *   Implementasi peran "Koordinator P5" jika diperlukan, dengan hak akses spesifik.
 
 ## 7. Perintah Berguna CodeIgniter Spark
 

--- a/README.md
+++ b/README.md
@@ -61,19 +61,20 @@ Berikut adalah status implementasi fitur berdasarkan dokumen desain:
     *   [X] CRUD untuk Projek P5 (termasuk pemilihan tema, target sub-elemen).
     *   [X] Alokasi Siswa ke Projek P5.
     *   [ ] Penentuan fasilitator/guru pendamping projek.
-*   **[ ] Fitur Penilaian P5 (Fasilitator/Guru)**
-    *   [ ] Antarmuka input penilaian kualitatif (BB, MB, BSH, SB) & catatan deskriptif per siswa per sub-elemen.
-*   **[ ] Fitur Pelaporan P5**
-    *   [ ] Rekapitulasi penilaian P5 (per siswa, per projek).
+*   **[P] Fitur Penilaian P5 (Fasilitator/Guru) (Dasar)**
+    *   [X] Antarmuka input penilaian kualitatif (BB, MB, BSH, SB) & catatan deskriptif per siswa per sub-elemen (Dasar).
+        *   *Catatan: Hak akses input penilaian saat ini terbuka untuk semua guru, perlu penyempurnaan setelah fitur penetapan fasilitator projek ada.*
+*   **[P] Fitur Pelaporan P5 (Dasar)**
+    *   [X] Rekapitulasi penilaian P5 per projek (per siswa, per sub-elemen) untuk Admin/Koordinator.
     *   [ ] Ekspor data P5 untuk e-Rapor (jika didukung).
 
 ### Modul Pendukung
 
-*   **[P] Modul Ekspor ke e-Rapor (Fitur Kunci - Tahap Awal)**
+*   **[X] Modul Ekspor ke e-Rapor (Fitur Kunci - Penyempurnaan Filter)**
     *   [X] Antarmuka Wali Kelas untuk parameter ekspor (Kelas, Tahun Ajaran, Semester).
-    *   [P] Proses penarikan data nilai sumatif (rata-rata per mapel).
-        *   *Catatan: Akurasi filter semester pada nilai sumatif perlu penyempurnaan.*
+    *   [X] Proses penarikan data nilai sumatif (rata-rata per mapel) dengan filter semester yang disempurnakan berdasarkan rentang tanggal.
     *   [X] Penyusunan & Unduh file Excel (.xlsx).
+        *   *Catatan: Pengguna disarankan memverifikasi format output Excel dengan template e-Rapor aktual.*
     *   [ ] Ekspor data P5 (menyusul setelah fitur penilaian & pelaporan P5 lengkap).
 
 ### Fitur Berdasarkan Peran Pengguna

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -127,6 +127,11 @@ $routes->group('admin', ['namespace' => 'App\Controllers\Admin', 'filter' => 'au
         'as' => 'admin_p5project_remove_student',
         'filter' => $p5ManagementFilter
     ]);
+    // P5 Project Report route
+    $routes->get('p5projects/report/(:num)', 'P5ProjectController::report/$1', [
+        'as' => 'admin_p5project_report',
+        'filter' => $p5ManagementFilter // Or a more specific view permission
+    ]);
 });
 
 // Guru routes
@@ -171,6 +176,11 @@ $routes->group('guru', ['namespace' => 'App\Controllers\Guru', 'filter' => 'auth
     // Cara yang lebih eksplisit:
     $routes->get('wali-kelas/erapor/export', '\App\Controllers\WaliKelas\EraporController::exportForm', ['as' => 'wali_kelas_erapor_form', 'filter' => 'auth:Guru']);
     $routes->post('wali-kelas/erapor/process', '\App\Controllers\WaliKelas\EraporController::processExport', ['as' => 'wali_kelas_erapor_process', 'filter' => 'auth:Guru']);
+
+    // P5 Assessment Routes for Guru/Facilitator
+    $routes->get('p5assessments', 'P5AssessmentController::selectProject', ['as' => 'guru_p5assessment_select_project']);
+    $routes->get('p5assessments/project/(:num)', 'P5AssessmentController::showAssessmentForm/$1', ['as' => 'guru_p5assessment_form']);
+    $routes->post('p5assessments/save/(:num)', 'P5AssessmentController::saveAssessments/$1', ['as' => 'guru_p5assessment_save']);
 });
 
 // Siswa routes

--- a/app/Controllers/Guru/P5AssessmentController.php
+++ b/app/Controllers/Guru/P5AssessmentController.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Controllers\Guru;
+
+use App\Controllers\BaseController;
+use App\Models\P5ProjectModel;
+use App\Models\P5ProjectStudentModel;
+use App\Models\P5AssessmentModel;
+use App\Models\TeacherModel;
+use App\Models\P5SubElementModel;
+
+class P5AssessmentController extends BaseController
+{
+    protected $p5ProjectModel;
+    protected $p5ProjectStudentModel;
+    protected $p5AssessmentModel;
+    protected $teacherModel;
+    protected $p5SubElementModel;
+    protected $teacherId;
+
+    public function __construct()
+    {
+        $this->p5ProjectModel = new P5ProjectModel();
+        $this->p5ProjectStudentModel = new P5ProjectStudentModel();
+        $this->p5AssessmentModel = new P5AssessmentModel();
+        $this->teacherModel = new TeacherModel();
+        $this->p5SubElementModel = new P5SubElementModel();
+
+        // Get logged in teacher id
+        $user_id = session()->get('user_id');
+        $teacher = $this->teacherModel->where('user_id', $user_id)->first();
+        if ($teacher) {
+            $this->teacherId = $teacher['id'];
+        } else {
+            // Handle if teacher not found, perhaps redirect or show error
+            // For now, let's assume teacher will always be found if logged in as guru
+            $this->teacherId = null;
+        }
+    }
+
+    public function selectProject()
+    {
+        // TODO: Get projects where the logged-in teacher is a facilitator
+        // For now, get all projects. This needs to be refined based on how facilitators are assigned.
+        // Assuming a direct assignment or a role that allows assessing all projects for simplicity now.
+        $data['projects'] = $this->p5ProjectModel->findAll();
+        return view('guru/p5assessments/select_project', $data);
+    }
+
+    public function showAssessmentForm($projectId)
+    {
+        $project = $this->p5ProjectModel->find($projectId);
+        if (!$project) {
+            return redirect()->back()->with('error', 'Projek P5 tidak ditemukan.');
+        }
+
+        // Get students in this project
+        $projectStudents = $this->p5ProjectStudentModel->where('p5_project_id', $projectId)
+                                                       ->join('students', 'students.id = p5_project_students.student_id')
+                                                       ->select('p5_project_students.id as p5_project_student_id, students.id as student_id, students.name as student_name, students.nis')
+                                                       ->findAll();
+
+        // Get target sub-elements for this project
+        $targetSubElements = $this->p5SubElementModel
+                                ->select('p5_sub_elements.id, p5_sub_elements.name, p5_elements.name as element_name, p5_dimensions.name as dimension_name')
+                                ->join('p5_project_target_sub_elements pstse', 'pstse.p5_sub_element_id = p5_sub_elements.id')
+                                ->join('p5_elements', 'p5_elements.id = p5_sub_elements.p5_element_id')
+                                ->join('p5_dimensions', 'p5_dimensions.id = p5_elements.p5_dimension_id')
+                                ->where('pstse.p5_project_id', $projectId)
+                                ->findAll();
+
+        $existingAssessments = [];
+        foreach ($projectStudents as $ps) {
+            foreach ($targetSubElements as $subElement) {
+                $assessment = $this->p5AssessmentModel
+                                    ->where('p5_project_student_id', $ps['p5_project_student_id'])
+                                    ->where('p5_sub_element_id', $subElement['id'])
+                                    ->first();
+                if ($assessment) {
+                    $existingAssessments[$ps['p5_project_student_id']][$subElement['id']] = $assessment;
+                }
+            }
+        }
+
+        $data = [
+            'project' => $project,
+            'projectStudents' => $projectStudents,
+            'targetSubElements' => $targetSubElements,
+            'existingAssessments' => $existingAssessments,
+            'assessment_options' => ['BB', 'MB', 'BSH', 'SB'] // Berkembang, Mulai Berkembang, Berkembang Sesuai Harapan, Sangat Berkembang
+        ];
+
+        return view('guru/p5assessments/assessment_form', $data);
+    }
+
+    public function saveAssessments($projectId)
+    {
+        if (!$this->teacherId) {
+            return redirect()->back()->with('error', 'Tidak dapat menyimpan penilaian. Data guru tidak ditemukan.');
+        }
+
+        $project = $this->p5ProjectModel->find($projectId);
+        if (!$project) {
+            return redirect()->back()->with('error', 'Projek P5 tidak ditemukan.');
+        }
+
+        $assessmentsData = $this->request->getPost('assessments');
+        $validationRules = [];
+        $validationMessages = [];
+        $dataToSave = [];
+
+        if (empty($assessmentsData)) {
+            return redirect()->back()->with('error', 'Tidak ada data penilaian yang dikirim.');
+        }
+
+        foreach ($assessmentsData as $p5ProjectStudentId => $subElements) {
+            foreach ($subElements as $subElementId => $values) {
+                $projectStudent = $this->p5ProjectStudentModel->find($p5ProjectStudentId);
+                if (!$projectStudent) continue; // Skip if invalid project_student_id
+
+                $student = $this->p5ProjectStudentModel->getStudent($projectStudent['student_id']);
+                $subElement = $this->p5SubElementModel->find($subElementId);
+                if (!$student || !$subElement) continue;
+
+                $assessmentValue = $values['assessment_value'] ?? null;
+                $notes = $values['notes'] ?? null;
+
+                // Only validate if at least one field is filled for this sub-element
+                if (!empty($assessmentValue) || !empty($notes)) {
+                    $validationRules["assessments.{$p5ProjectStudentId}.{$subElementId}.assessment_value"] = 'permit_empty|in_list[BB,MB,BSH,SB]';
+                    $validationMessages["assessments.{$p5ProjectStudentId}.{$subElementId}.assessment_value.in_list"] = "Nilai untuk {$student['name']} - {$subElement['name']} harus salah satu dari BB, MB, BSH, SB.";
+                }
+
+
+                // Check if assessment already exists
+                $existingAssessment = $this->p5AssessmentModel
+                    ->where('p5_project_student_id', $p5ProjectStudentId)
+                    ->where('p5_sub_element_id', $subElementId)
+                    ->first();
+
+                if ($existingAssessment) {
+                    // Update existing assessment
+                    if (!empty($assessmentValue) || !empty($notes) || $existingAssessment['assessment_value'] || $existingAssessment['notes']) {
+                         $updateData = [
+                            'assessment_value' => $assessmentValue,
+                            'notes' => $notes,
+                            'assessed_by' => $this->teacherId,
+                            'assessment_date' => date('Y-m-d')
+                        ];
+                        if (empty($assessmentValue) && empty($notes)) { // If both are emptied, consider it a delete or clear
+                             $this->p5AssessmentModel->delete($existingAssessment['id']);
+                        } else {
+                             $this->p5AssessmentModel->update($existingAssessment['id'], $updateData);
+                        }
+                    }
+                } elseif (!empty($assessmentValue) || !empty($notes)) {
+                    // Insert new assessment
+                    $dataToSave[] = [
+                        'p5_project_student_id' => $p5ProjectStudentId,
+                        'p5_sub_element_id' => $subElementId,
+                        'assessment_value' => $assessmentValue,
+                        'notes' => $notes,
+                        'assessed_by' => $this->teacherId,
+                        'assessment_date' => date('Y-m-d')
+                    ];
+                }
+            }
+        }
+
+        if (!empty($validationRules) && !$this->validate($validationRules, $validationMessages)) {
+            return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
+        }
+
+        if (!empty($dataToSave)) {
+            if (!$this->p5AssessmentModel->insertBatch($dataToSave)) {
+                // Log error or handle
+                return redirect()->back()->with('error', 'Gagal menyimpan sebagian data penilaian baru.')->withInput();
+            }
+        }
+
+        return redirect()->to('guru/p5assessments/project/' . $projectId)->with('success', 'Penilaian P5 berhasil disimpan.');
+    }
+}

--- a/app/Views/admin/p5projects/index.php
+++ b/app/Views/admin/p5projects/index.php
@@ -61,6 +61,7 @@
                                     <td>
                                         <a href="<?= site_url('admin/p5projects/edit/' . $project['id']) ?>" class="btn btn-sm btn-warning mb-1" title="Edit Project Details"><i class="fas fa-edit"></i></a>
                                         <a href="<?= route_to('admin_p5project_manage_students', $project['id']) ?>" class="btn btn-sm btn-info mb-1" title="Manage Students"><i class="fas fa-users"></i></a>
+                                        <a href="<?= route_to('admin_p5project_report', $project['id']) ?>" class="btn btn-sm btn-success mb-1" title="View Report"><i class="fas fa-chart-bar"></i></a>
                                         <button type="button" class="btn btn-sm btn-danger mb-1" title="Delete Project" onclick="confirmDelete('<?= site_url('admin/p5projects/delete/' . $project['id']) ?>')"><i class="fas fa-trash"></i></button>
                                     </td>
                                 </tr>

--- a/app/Views/admin/p5projects/report.php
+++ b/app/Views/admin/p5projects/report.php
@@ -1,0 +1,151 @@
+<?= $this->extend('layouts/admin_default') ?>
+
+<?= $this->section('content') ?>
+<div class="container-fluid">
+    <h1 class="h3 mb-2 text-gray-800"><?= esc($title) ?></h1>
+    <p class="mb-4">
+        <strong>Tema:</strong> <?= esc($project['theme_name'] ?? 'Belum Ditentukan') ?><br>
+        <strong>Periode Projek:</strong> <?= esc(date('d M Y', strtotime($project['start_date']))) ?> - <?= esc(date('d M Y', strtotime($project['end_date']))) ?><br>
+        <strong>Deskripsi:</strong> <?= esc($project['description']) ?>
+    </p>
+
+    <?php if (session()->getFlashdata('message')) : ?>
+        <div class="alert alert-success"><?= session()->getFlashdata('message') ?></div>
+    <?php endif; ?>
+    <?php if (session()->getFlashdata('error')) : ?>
+        <div class="alert alert-danger"><?= session()->getFlashdata('error') ?></div>
+    <?php endif; ?>
+
+    <div class="card shadow mb-4">
+        <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
+            <h6 class="m-0 font-weight-bold text-primary">Detail Penilaian Projek</h6>
+            <a href="<?= site_url('admin/p5projects') ?>" class="btn btn-secondary btn-sm">
+                <i class="fas fa-arrow-left"></i> Kembali ke Daftar Projek
+            </a>
+        </div>
+        <div class="card-body">
+            <?php if (!empty($projectStudents) && is_array($projectStudents)) : ?>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-striped" id="p5ReportTable" width="100%" cellspacing="0">
+                        <thead>
+                            <tr>
+                                <th rowspan="2" class="align-middle text-center">No</th>
+                                <th rowspan="2" class="align-middle text-center">NIS</th>
+                                <th rowspan="2" class="align-middle text-center">Nama Siswa</th>
+                                <?php
+                                if (!empty($targetSubElements)) {
+                                    $dimensionSpans = [];
+                                    $elementSpans = [];
+                                    $headerRows = ['dimensions' => [], 'elements' => [], 'sub_elements' => []];
+
+                                    foreach ($targetSubElements as $sub) {
+                                        $dimName = esc($sub['dimension_name']);
+                                        $elName = esc($sub['element_name']);
+                                        $subName = esc($sub['name']);
+
+                                        if (!isset($dimensionSpans[$dimName])) {
+                                            $dimensionSpans[$dimName] = 0;
+                                            $headerRows['dimensions'][$dimName] = ['name' => $dimName, 'span' => 0];
+                                        }
+                                        if (!isset($elementSpans[$dimName][$elName])) {
+                                            $elementSpans[$dimName][$elName] = 0;
+                                            $headerRows['elements'][$dimName][$elName] = ['name' => $elName, 'span' => 0];
+                                        }
+
+                                        $dimensionSpans[$dimName]++;
+                                        $elementSpans[$dimName][$elName]++;
+                                        $headerRows['sub_elements'][] = ['name' => $subName, 'dim' => $dimName, 'el' => $elName ];
+                                    }
+
+                                    foreach($headerRows['dimensions'] as $dimKey => &$dimVal){
+                                        $dimVal['span'] = $dimensionSpans[$dimKey] * 2; // *2 for value and notes
+                                    }
+                                    foreach($headerRows['elements'] as $dimKey => &$elGroup){
+                                        foreach($elGroup as $elKey => &$elVal){
+                                            $elVal['span'] = $elementSpans[$dimKey][$elKey] * 2; // *2 for value and notes
+                                        }
+                                    }
+                                }
+                                ?>
+                                <?php if (!empty($headerRows['dimensions'])) : ?>
+                                    <?php foreach ($headerRows['dimensions'] as $dim) : ?>
+                                        <th colspan="<?= $dim['span'] ?>" class="text-center"><?= $dim['name'] ?></th>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
+                            </tr>
+                            <tr>
+                                <?php if (!empty($headerRows['elements'])) : ?>
+                                    <?php foreach ($headerRows['elements'] as $dimKey => $elGroup) : ?>
+                                        <?php foreach ($elGroup as $el) : ?>
+                                            <th colspan="<?= $el['span'] ?>" class="text-center"><?= $el['name'] ?></th>
+                                        <?php endforeach; ?>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
+                            </tr>
+                            <tr>
+                                <?php if (!empty($headerRows['sub_elements'])) : ?>
+                                    <?php foreach ($headerRows['sub_elements'] as $sub) : ?>
+                                        <th class="text-center" title="Sub Elemen: <?= $sub['name'] ?>"><small><?= $sub['name'] ?><br>(Nilai)</small></th>
+                                        <th class="text-center" title="Sub Elemen: <?= $sub['name'] ?>"><small><?= $sub['name'] ?><br>(Catatan)</small></th>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php $no = 1; ?>
+                            <?php foreach ($projectStudents as $student) : ?>
+                                <tr>
+                                    <td class="text-center"><?= $no++ ?></td>
+                                    <td><?= esc($student['nis']) ?></td>
+                                    <td><?= esc($student['student_name']) ?></td>
+                                    <?php if (!empty($targetSubElements)) : ?>
+                                        <?php foreach ($targetSubElements as $subElement) : ?>
+                                            <?php
+                                            $assessment = $assessmentsData[$student['p5_project_student_id']][$subElement['id']] ?? null;
+                                            $assessmentValue = $assessment ? esc($assessment['assessment_value']) : '-';
+                                            $assessmentNotes = $assessment ? esc($assessment['notes']) : '-';
+                                            $assessor = $assessment && $assessment['assessor_name'] ? esc($assessment['assessor_name']) : 'N/A';
+                                            $date = $assessment && $assessment['assessment_date'] ? esc(date('d/m/y', strtotime($assessment['assessment_date']))) : 'N/A';
+                                            $title = "Penilai: {$assessor}\nTanggal: {$date}\nCatatan: {$assessmentNotes}";
+                                            ?>
+                                            <td class="text-center" title="<?= $title ?>">
+                                                <?= $assessmentValue ?>
+                                            </td>
+                                             <td title="<?= $title ?>">
+                                                <?= nl2br($assessmentNotes) ?>
+                                            </td>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php else : ?>
+                <p>Tidak ada siswa yang dialokasikan untuk projek ini atau tidak ada sub-elemen target yang ditentukan.</p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+<!-- DataTables -->
+<script>
+    $(document).ready(function() {
+        $('#p5ReportTable').DataTable({
+            responsive: true,
+            dom: 'Bfrtip', // Add B for Buttons
+            buttons: [
+                { extend: 'copy', className: 'btn-sm' },
+                { extend: 'csv', className: 'btn-sm' },
+                { extend: 'excel', className: 'btn-sm', title: '<?= esc($title) ?>' },
+                { extend: 'pdf', className: 'btn-sm', title: '<?= esc($title) ?>', orientation: 'landscape', pageSize: 'LEGAL' },
+                { extend: 'print', className: 'btn-sm', title: '<?= esc($title) ?>' }
+            ],
+            pageLength: 25, // Default number of rows to display
+            order: [], // Disable initial sorting
+        });
+    });
+</script>
+<?= $this->endSection() ?>

--- a/app/Views/guru/p5assessments/assessment_form.php
+++ b/app/Views/guru/p5assessments/assessment_form.php
@@ -1,0 +1,121 @@
+<?= $this->extend('layouts/admin_default') ?>
+
+<?= $this->section('content') ?>
+<div class="container-fluid">
+    <h1 class="h3 mb-2 text-gray-800">Input Penilaian P5: <?= esc($project['name']) ?></h1>
+    <p class="mb-4">Periode Projek: <?= esc(date('d M Y', strtotime($project['start_date']))) ?> - <?= esc(date('d M Y', strtotime($project['end_date']))) ?></p>
+
+    <?php if (session()->getFlashdata('success')) : ?>
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <?= session()->getFlashdata('success') ?>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+    <?php endif; ?>
+    <?php if (session()->getFlashdata('error')) : ?>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <?= session()->getFlashdata('error') ?>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+    <?php endif; ?>
+    <?php if (session()->has('errors')) : ?>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <p><strong>Terjadi Kesalahan Validasi:</strong></p>
+            <ul>
+                <?php foreach (session('errors') as $error) : ?>
+                    <li><?= esc($error) ?></li>
+                <?php endforeach ?>
+            </ul>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+    <?php endif; ?>
+
+
+    <form action="<?= site_url('guru/p5assessments/save/' . $project['id']) ?>" method="post">
+        <?= csrf_field() ?>
+        <div class="card shadow mb-4">
+            <div class="card-header py-3">
+                <h6 class="m-0 font-weight-bold text-primary">Form Penilaian</h6>
+            </div>
+            <div class="card-body">
+                <?php if (!empty($projectStudents) && is_array($projectStudents)) : ?>
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="assessmentTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th rowspan="2" class="align-middle text-center">No</th>
+                                    <th rowspan="2" class="align-middle text-center">NIS</th>
+                                    <th rowspan="2" class="align-middle text-center">Nama Siswa</th>
+                                    <?php if (!empty($targetSubElements)) : ?>
+                                        <?php
+                                        $dimensionSpan = [];
+                                        foreach ($targetSubElements as $subElement) {
+                                            $dimensionSpan[$subElement['dimension_name']] = ($dimensionSpan[$subElement['dimension_name']] ?? 0) + 1;
+                                        }
+                                        ?>
+                                        <?php foreach ($dimensionSpan as $dimName => $span) : ?>
+                                            <th colspan="<?= $span * 2 ?>" class="text-center"><?= esc($dimName) ?></th>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </tr>
+                                <tr>
+                                    <?php if (!empty($targetSubElements)) : ?>
+                                        <?php foreach ($targetSubElements as $subElement) : ?>
+                                            <th class="text-center" title="<?= esc($subElement['element_name']) ?>"><?= esc($subElement['name']) ?><br><small>(Nilai)</small></th>
+                                            <th class="text-center" title="<?= esc($subElement['element_name']) ?>"><?= esc($subElement['name']) ?><br><small>(Catatan)</small></th>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php $no = 1; ?>
+                                <?php foreach ($projectStudents as $student) : ?>
+                                    <tr>
+                                        <td class="text-center"><?= $no++ ?></td>
+                                        <td><?= esc($student['nis']) ?></td>
+                                        <td><?= esc($student['student_name']) ?></td>
+                                        <?php if (!empty($targetSubElements)) : ?>
+                                            <?php foreach ($targetSubElements as $subElement) : ?>
+                                                <?php
+                                                $currentAssessmentValue = $existingAssessments[$student['p5_project_student_id']][$subElement['id']]['assessment_value'] ?? '';
+                                                $currentNotes = $existingAssessments[$student['p5_project_student_id']][$subElement['id']]['notes'] ?? '';
+                                                ?>
+                                                <td>
+                                                    <select name="assessments[<?= esc($student['p5_project_student_id']) ?>][<?= esc($subElement['id']) ?>][assessment_value]" class="form-control form-control-sm">
+                                                        <option value="">- Pilih -</option>
+                                                        <?php foreach ($assessment_options as $option) : ?>
+                                                            <option value="<?= esc($option) ?>" <?= ($currentAssessmentValue == $option) ? 'selected' : '' ?>><?= esc($option) ?></option>
+                                                        <?php endforeach; ?>
+                                                    </select>
+                                                </td>
+                                                <td>
+                                                    <textarea name="assessments[<?= esc($student['p5_project_student_id']) ?>][<?= esc($subElement['id']) ?>][notes]" class="form-control form-control-sm" rows="2"><?= esc($currentNotes) ?></textarea>
+                                                </td>
+                                            <?php endforeach; ?>
+                                        <?php endif; ?>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php else : ?>
+                    <p>Tidak ada siswa yang dialokasikan untuk projek ini.</p>
+                <?php endif; ?>
+            </div>
+            <div class="card-footer">
+                <a href="<?= site_url('guru/p5assessments') ?>" class="btn btn-secondary">Kembali ke Pilih Projek</a>
+                <?php if (!empty($projectStudents)) : ?>
+                <button type="submit" class="btn btn-primary">Simpan Penilaian</button>
+                <?php endif; ?>
+            </div>
+        </div>
+    </form>
+</div>
+
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+<script>
+    // Optional: Add any JavaScript needed for the form, e.g., dynamic interactions.
+    // For now, standard submit is handled.
+</script>
+<?= $this->endSection() ?>

--- a/app/Views/guru/p5assessments/select_project.php
+++ b/app/Views/guru/p5assessments/select_project.php
@@ -1,0 +1,37 @@
+<?= $this->extend('layouts/admin_default') ?>
+
+<?= $this->section('content') ?>
+<div class="container-fluid">
+    <h1 class="h3 mb-4 text-gray-800">Pilih Projek P5 untuk Penilaian</h1>
+
+    <?php if (session()->getFlashdata('success')) : ?>
+        <div class="alert alert-success"><?= session()->getFlashdata('success') ?></div>
+    <?php endif; ?>
+    <?php if (session()->getFlashdata('error')) : ?>
+        <div class="alert alert-danger"><?= session()->getFlashdata('error') ?></div>
+    <?php endif; ?>
+
+    <div class="card shadow mb-4">
+        <div class="card-header py-3">
+            <h6 class="m-0 font-weight-bold text-primary">Daftar Projek P5</h6>
+        </div>
+        <div class="card-body">
+            <?php if (!empty($projects) && is_array($projects)) : ?>
+                <div class="list-group">
+                    <?php foreach ($projects as $project) : ?>
+                        <a href="<?= site_url('guru/p5assessments/project/' . esc($project['id'])) ?>" class="list-group-item list-group-item-action">
+                            <div class="d-flex w-100 justify-content-between">
+                                <h5 class="mb-1"><?= esc($project['name']) ?></h5>
+                                <small>Periode: <?= esc(date('d M Y', strtotime($project['start_date']))) ?> - <?= esc(date('d M Y', strtotime($project['end_date']))) ?></small>
+                            </div>
+                            <p class="mb-1"><?= esc($project['description']) ?></p>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            <?php else : ?>
+                <p>Tidak ada projek P5 yang tersedia atau Anda belum ditugaskan sebagai fasilitator.</p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+<?= $this->endSection() ?>

--- a/app/Views/layouts/admin_default.php
+++ b/app/Views/layouts/admin_default.php
@@ -131,6 +131,10 @@
                                         <a class="dropdown-item <?= (strpos(uri_string(), 'guru/assessments/recap') !== false || strpos(uri_string(), 'guru/assessments/show-recap') !== false) ? 'active' : '' ?>"
                                            href="<?= route_to('guru_assessment_recap_select') ?>">Rekap Nilai</a>
                                     </li>
+                                    <li>
+                                        <a class="dropdown-item <?= (strpos(uri_string(), 'guru/p5assessments') !== false) ? 'active' : '' ?>"
+                                           href="<?= route_to('guru_p5assessment_select_project') ?>">Input Nilai P5</a>
+                                    </li>
                                     <li><hr class="dropdown-divider"></li>
                                     <li><h6 class="dropdown-header">Wali Kelas</h6></li>
                                     <li>


### PR DESCRIPTION
- Adds feature for teachers/facilitators to input P5 assessments (qualitative scores and notes) per student per sub-element for a project.
- Current P5 assessment input access is open to all teachers; needs refinement with facilitator assignment feature.
- Adds basic P5 project reporting for admins, showing assessment details per student/sub-element with export options.
- Enhances e-Rapor export module by implementing date-based filtering for summative assessments according to the selected academic year and semester.
- Updates README.md and AGENTS.md to reflect these new features and improvements.