### PR TITLE
feat: Implement tests for core data models

### DIFF
--- a/app/Database/Seeds/UserRoleSeeder.php
+++ b/app/Database/Seeds/UserRoleSeeder.php
@@ -15,9 +15,10 @@ class UserRoleSeeder extends Seeder
 
         // Define roles to ensure they exist
         $roles = [
-            ['role_name' => 'Administrator Sistem'], // Assuming this is the admin role
+            ['role_name' => 'Administrator Sistem'],
             ['role_name' => 'Guru'],
             ['role_name' => 'Siswa'],
+            ['role_name' => 'Orang Tua'], // Added Orang Tua role
         ];
 
         foreach ($roles as $roleData) {
@@ -70,6 +71,51 @@ class UserRoleSeeder extends Seeder
             } else {
                 // echo "User '{$userData['username']}' already exists. Skipping.\n";
             }
+        }
+
+        // Additionally, create a Teacher record for 'testguru' user
+        $guruUser = $userModel->where('username', 'testguru')->first();
+        if ($guruUser) {
+            $teacherModel = new \App\Models\TeacherModel();
+            $existingTeacher = $teacherModel->where('user_id', $guruUser['id'])->first();
+            if (!$existingTeacher) {
+                $teacherData = [
+                    'full_name' => $guruUser['full_name'] ?? 'Guru Test (Wali Kelas)',
+                    'nip'       => 'NIP-GURU-' . substr(uniqid(), -6), // Ensure unique NIP
+                    'user_id'   => $guruUser['id'],
+                ];
+                if ($teacherModel->insert($teacherData)) {
+                    // echo "Teacher record for 'testguru' created.\n";
+                } else {
+                    // echo "Failed to create teacher record for 'testguru'. Errors: " . implode(', ', $teacherModel->errors()) . "\n";
+                }
+            }
+        }
+
+        // Add Siswa Test User and Ortu Test User
+        $siswaRole = $roleModel->where('role_name', 'Siswa')->first();
+        $ortuRole  = $roleModel->where('role_name', 'Orang Tua')->first(); // Assuming 'Orang Tua' role exists from RoleSeeder logic
+
+        if ($siswaRole && !$userModel->where('username', 'testsiswa')->first()) {
+            $userModel->insert([
+                'username'  => 'testsiswa',
+                'password'  => 'password123',
+                'password_confirm' => 'password123',
+                'full_name' => 'Siswa Test User',
+                'role_id'   => $siswaRole['id'],
+                'is_active' => 1,
+            ]);
+        }
+
+        if ($ortuRole && !$userModel->where('username', 'testortu')->first()) {
+            $userModel->insert([
+                'username'  => 'testortu',
+                'password'  => 'password123',
+                'password_confirm' => 'password123',
+                'full_name' => 'Ortu Test User',
+                'role_id'   => $ortuRole['id'],
+                'is_active' => 1,
+            ]);
         }
     }
 }

--- a/tests/Models/RoleModelTest.php
+++ b/tests/Models/RoleModelTest.php
@@ -2,98 +2,163 @@
 
 namespace Tests\Models;
 
-use App\Models\RoleModel;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use App\Models\RoleModel;
+use App\Models\UserModel; // To test FK constraint with users table
 
 class RoleModelTest extends CIUnitTestCase
 {
-    use DatabaseTestTrait; // Provides migration and seeder features for tests
+    use DatabaseTestTrait;
 
-    protected $namespace   = 'App'; // Specify the namespace for migrations
-    protected $refresh     = true; // Refresh database for each test class
-    // protected $migrate     = true; // Automatically run migrations - redundant if refresh is true
-    // protected $migrateOnce = false; // Run migrations for each test method for isolation - redundant if refresh is true
-    protected $seed        = 'App\Database\Seeds\RoleSeeder'; // Use FQCN
-    // Or use $seedOnce = true; and $this->seeInDatabase('roles', ['role_name' => 'Administrator Sistem']);
-    // For this simple model, seeding per method is fine.
+    protected $migrate = true;
+    protected $refresh = true;
+    protected $namespace = 'App';
+    // Not using UserRoleSeeder here to have a cleaner slate specifically for role tests,
+    // and to avoid potential conflicts if UserRoleSeeder creates roles that this test also tries to create.
+    // protected $seed = 'UserRoleSeeder';
+    // protected $basePath = APPPATH . 'Database';
 
-    protected $model;
+
+    protected $roleModel;
+    protected $userModel;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->model = new RoleModel();
+        // It's important that migrations for roles and users tables are run.
+        // $this->db->table('roles')->truncate(); // Optional: ensure clean roles table if not using $refresh or specific seeder
+        // $this->db->table('users')->truncate(); // Optional: ensure clean users table
+        $this->roleModel = new RoleModel();
+        $this->userModel = new UserModel();
     }
 
-    public function testFindAllRoles()
+    protected function tearDown(): void
     {
-        $roles = $this->model->findAll();
-
-        // We expect 6 roles from RoleSeeder
-        $this->assertCount(6, $roles);
-
-        // Check if a specific known role exists
-        $this->assertTrue(in_array('Administrator Sistem', array_column($roles, 'role_name')));
-        $this->assertTrue(in_array('Siswa', array_column($roles, 'role_name')));
+        parent::tearDown();
+        unset($this->roleModel);
+        unset($this->userModel);
     }
 
-    public function testRoleNameIsRequired()
+    public function testCreateRoleWithValidData()
+    {
+        $data = ['role_name' => 'Test Role One'];
+        $roleId = $this->roleModel->insert($data);
+
+        $this->assertIsNumeric($roleId, "Insert should return the new role ID. Errors: ".implode(', ', $this->roleModel->errors()));
+        $this->seeInDatabase('roles', ['role_name' => 'Test Role One', 'id' => $roleId]);
+    }
+
+    public function testCreateRoleFailsIfNameMissing()
     {
         $data = ['role_name' => ''];
-        $this->assertFalse($this->model->insert($data));
+        $result = $this->roleModel->insert($data);
+        $errors = $this->roleModel->errors();
 
-        $errors = $this->model->errors();
+        $this->assertFalse($result, "Insert should fail if role_name is missing/empty.");
+        $this->assertArrayHasKey('role_name', $errors, "Validation errors should contain 'role_name'.");
+        // Check for 'required' part of the message.
+        $this->assertMatchesRegularExpression('/required/i', $errors['role_name']);
+    }
+
+    public function testCreateRoleFailsIfNameTooShort()
+    {
+        $data = ['role_name' => 'AB']; // Too short (min_length[3])
+        $result = $this->roleModel->insert($data);
+        $errors = $this->roleModel->errors();
+
+        $this->assertFalse($result, "Insert should fail if role_name is too short.");
         $this->assertArrayHasKey('role_name', $errors);
-        $this->assertStringContainsStringIgnoringCase('The role_name field is required.', $errors['role_name']);
+        $this->assertStringContainsStringIgnoringCase('at least 3 characters', $errors['role_name']);
     }
 
-    public function testRoleNameMinLength()
+
+    public function testCreateRoleFailsIfNameTaken()
     {
-        $data = ['role_name' => 'Ad']; // Too short
-        $this->assertFalse($this->model->insert($data));
-        $errors = $this->model->errors();
+        $initialData = ['role_name' => 'Unique Role Name'];
+        $firstRoleId = $this->roleModel->insert($initialData);
+        $this->assertIsNumeric($firstRoleId, "First role should be inserted successfully.");
+
+        $duplicateData = ['role_name' => 'Unique Role Name'];
+        $result = $this->roleModel->insert($duplicateData);
+        $errors = $this->roleModel->errors();
+
+        $this->assertFalse($result, "Insert should fail if role_name is already taken.");
         $this->assertArrayHasKey('role_name', $errors);
-        $this->assertStringContainsStringIgnoringCase('must be at least 3 characters in length', $errors['role_name']);
+        $this->assertEquals('This role name already exists.', $errors['role_name']);
     }
 
-    public function testRoleNameIsUnique()
+    public function testUpdateRoleName()
     {
-        // RoleSeeder already added 'Guru'
-        $data = ['role_name' => 'Guru'];
-        $this->assertFalse($this->model->insert($data));
+        $data = ['role_name' => 'Original Role Name'];
+        $roleId = $this->roleModel->insert($data);
+        $this->assertIsNumeric($roleId);
 
-        $errors = $this->model->errors();
+        $updatedData = ['role_name' => 'Updated Role Name'];
+        $result = $this->roleModel->update($roleId, $updatedData);
+
+        $this->assertTrue($result, "Update should return true. Errors: ".implode(', ', $this->roleModel->errors()));
+        $this->seeInDatabase('roles', ['id' => $roleId, 'role_name' => 'Updated Role Name']);
+        $this->dontSeeInDatabase('roles', ['id' => $roleId, 'role_name' => 'Original Role Name']);
+    }
+
+    public function testUpdateRoleNameToExistingNameFails()
+    {
+        $this->roleModel->insert(['role_name' => 'Existing Role A']);
+        $roleB_id = $this->roleModel->insert(['role_name' => 'Role B To Update']);
+        $this->assertIsNumeric($roleB_id);
+
+        $updatedData = ['role_name' => 'Existing Role A'];
+        $result = $this->roleModel->update($roleB_id, $updatedData);
+        $errors = $this->roleModel->errors();
+
+        $this->assertFalse($result, "Update should fail if new role_name is already taken by another role.");
         $this->assertArrayHasKey('role_name', $errors);
-        $this->assertStringContainsStringIgnoringCase('This role name already exists.', $errors['role_name']);
+        $this->assertEquals('This role name already exists.', $errors['role_name']);
+        $this->seeInDatabase('roles', ['id' => $roleB_id, 'role_name' => 'Role B To Update']);
     }
 
-    public function testCreateValidRole()
+    public function testDeleteRoleNotUsedByUser()
     {
-        $data = ['role_name' => 'New Test Role'];
-        $result = $this->model->insert($data);
+        $data = ['role_name' => 'Role To Delete'];
+        $roleId = $this->roleModel->insert($data);
+        $this->assertIsNumeric($roleId);
 
-        $this->assertIsNumeric($result); // insert() returns the new ID
-        $this->seeInDatabase('roles', ['role_name' => 'New Test Role']);
+        $result = $this->roleModel->delete($roleId);
+        $this->assertTrue($result, "Delete should return true for an unused role.");
+        $this->dontSeeInDatabase('roles', ['id' => $roleId]);
     }
 
-    public function testUpdateRole()
+    public function testDeleteRoleUsedByUserSetsUserRoleIdToNull()
     {
-        // Get one of the seeded roles, e.g., 'Siswa'
-        $role = $this->model->where('role_name', 'Siswa')->first();
-        $this->assertNotNull($role);
+        // 1. Create a new role
+        $roleData = ['role_name' => 'Temporary Role For User'];
+        $roleId = $this->roleModel->insert($roleData);
+        $this->assertIsNumeric($roleId, "Temporary role should be created.");
+        $this->seeInDatabase('roles', ['id' => $roleId]);
 
-        $updatedName = 'Siswa Updated';
-        $this->model->update($role['id'], ['role_name' => $updatedName]);
-        $this->seeInDatabase('roles', ['id' => $role['id'], 'role_name' => $updatedName]);
-    }
+        // 2. Create a user assigned to this role
+        // Make sure this user data is valid according to UserModel rules
+        $userData = [
+            'username' => 'userwithtemprole',
+            'password' => 'password123',
+            'password_confirm' => 'password123', // Required by UserModel validation
+            'full_name' => 'User With Temporary Role',
+            'role_id'   => $roleId,
+            'is_active' => 1,
+        ];
+        $userId = $this->userModel->insert($userData);
+        $this->assertIsNumeric($userId, "User for role deletion test should be created. Errors: " . implode(', ', $this->userModel->errors()));
+        $this->seeInDatabase('users', ['id' => $userId, 'role_id' => $roleId]);
 
-    public function testDeleteRole()
-    {
-        $role = $this->model->where('role_name', 'Orang Tua')->first();
-        $this->assertNotNull($role);
+        // 3. Delete the role
+        $deleteResult = $this->roleModel->delete($roleId);
+        $this->assertTrue($deleteResult, "Deleting the role should be successful.");
+        $this->dontSeeInDatabase('roles', ['id' => $roleId]);
 
-        $this->model->delete($role['id']);
-        $this->dontSeeInDatabase('roles', ['id' => $role['id']]);
+        // 4. Verify user's role_id is now NULL
+        $updatedUser = $this->userModel->find($userId);
+        $this->assertNotNull($updatedUser, "User should still exist after role deletion.");
+        $this->assertNull($updatedUser['role_id'], "User's role_id should be NULL after the assigned role is deleted.");
     }
 }


### PR DESCRIPTION
- Add comprehensive tests for RoleModel, SubjectModel, TeacherModel, ClassModel, and StudentModel, covering CRUD operations and validation rules.
- Enhance UserRoleSeeder to create 'Siswa' and 'Orang Tua' roles, and corresponding 'testsiswa' and 'testortu' users to facilitate testing of foreign key relationships in StudentModel.
- Ensure UserRoleSeeder also creates a Teacher record linked to the 'testguru' user, providing a reliable 'wali_kelas_id' for ClassModel tests.
- All new model tests are passing.
- Existing tests for Admin/UserController, AuthController, and UserModel remain stable and passing.

Note: Pre-existing errors in other older Admin controller tests persist and are documented in AGENTS.md for separate attention.